### PR TITLE
Intercept inserted JSON

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -9,12 +9,12 @@
 /* Begin PBXBuildFile section */
 		14154D871DBC465700926D4D /* DATAStack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14241F151DBC3DE60042ED81 /* DATAStack.framework */; };
 		14154D881DBC465700926D4D /* SYNCPropertyMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14241F161DBC3DE60042ED81 /* SYNCPropertyMapper.framework */; };
-		14154D8B1DBC465B00926D4D /* DATAStack.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14154D891DBC465B00926D4D /* DATAStack.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		14154D8C1DBC465B00926D4D /* SYNCPropertyMapper.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14154D8A1DBC465B00926D4D /* SYNCPropertyMapper.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		14154D8B1DBC465B00926D4D /* DATAStack.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14154D891DBC465B00926D4D /* DATAStack.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		14154D8C1DBC465B00926D4D /* SYNCPropertyMapper.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14154D8A1DBC465B00926D4D /* SYNCPropertyMapper.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		14154D8F1DBC466200926D4D /* DATAStack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14154D8D1DBC466200926D4D /* DATAStack.framework */; };
 		14154D901DBC466200926D4D /* SYNCPropertyMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14154D8E1DBC466200926D4D /* SYNCPropertyMapper.framework */; };
-		14154D931DBC466700926D4D /* DATAStack.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14154D911DBC466700926D4D /* DATAStack.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		14154D941DBC466700926D4D /* SYNCPropertyMapper.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14154D921DBC466700926D4D /* SYNCPropertyMapper.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		14154D931DBC466700926D4D /* DATAStack.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14154D911DBC466700926D4D /* DATAStack.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		14154D941DBC466700926D4D /* SYNCPropertyMapper.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14154D921DBC466700926D4D /* SYNCPropertyMapper.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		1421405D1DBCDD52000FF107 /* Tests.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1421405B1DBCDD52000FF107 /* Tests.xcdatamodeld */; };
 		1421405E1DBCDD52000FF107 /* Tests.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1421405B1DBCDD52000FF107 /* Tests.xcdatamodeld */; };
 		1421405F1DBCDD52000FF107 /* Tests.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1421405B1DBCDD52000FF107 /* Tests.xcdatamodeld */; };
@@ -52,8 +52,8 @@
 		14241F0C1DBC3CDF0042ED81 /* SYNCPropertyMapper.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14241F0A1DBC3CDF0042ED81 /* SYNCPropertyMapper.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		14241F0F1DBC3D7D0042ED81 /* DATAStack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14241F0D1DBC3D7D0042ED81 /* DATAStack.framework */; };
 		14241F101DBC3D7D0042ED81 /* SYNCPropertyMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14241F0E1DBC3D7D0042ED81 /* SYNCPropertyMapper.framework */; };
-		14241F131DBC3D820042ED81 /* DATAStack.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14241F111DBC3D820042ED81 /* DATAStack.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		14241F141DBC3D820042ED81 /* SYNCPropertyMapper.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14241F121DBC3D820042ED81 /* SYNCPropertyMapper.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		14241F131DBC3D820042ED81 /* DATAStack.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14241F111DBC3D820042ED81 /* DATAStack.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		14241F141DBC3D820042ED81 /* SYNCPropertyMapper.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14241F121DBC3D820042ED81 /* SYNCPropertyMapper.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		14241F171DBC3DE60042ED81 /* DATAStack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14241F151DBC3DE60042ED81 /* DATAStack.framework */; };
 		14241F181DBC3DE60042ED81 /* SYNCPropertyMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14241F161DBC3DE60042ED81 /* SYNCPropertyMapper.framework */; };
 		14241F1B1DBC3DEB0042ED81 /* DATAStack.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14241F191DBC3DEB0042ED81 /* DATAStack.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -288,8 +288,8 @@
 		14C046351DBC19D300CB6C16 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C046341DBC19D300CB6C16 /* JSON.swift */; };
 		14DAB3FD1DBC4620004B455F /* DATAStack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14241F0D1DBC3D7D0042ED81 /* DATAStack.framework */; };
 		14DAB3FE1DBC4620004B455F /* SYNCPropertyMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14241F0E1DBC3D7D0042ED81 /* SYNCPropertyMapper.framework */; };
-		14DAB4011DBC4625004B455F /* DATAStack.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14DAB3FF1DBC4625004B455F /* DATAStack.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		14DAB4021DBC4625004B455F /* SYNCPropertyMapper.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14DAB4001DBC4625004B455F /* SYNCPropertyMapper.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		14DAB4011DBC4625004B455F /* DATAStack.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14DAB3FF1DBC4625004B455F /* DATAStack.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		14DAB4021DBC4625004B455F /* SYNCPropertyMapper.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14DAB4001DBC4625004B455F /* SYNCPropertyMapper.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		14E93C441DBCCD2800E3304E /* Sync.h in Headers */ = {isa = PBXBuildFile; fileRef = 14E93C431DBCCD2800E3304E /* Sync.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		14E93C451DBCCD2800E3304E /* Sync.h in Headers */ = {isa = PBXBuildFile; fileRef = 14E93C431DBCCD2800E3304E /* Sync.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		14E93C461DBCCD2800E3304E /* Sync.h in Headers */ = {isa = PBXBuildFile; fileRef = 14E93C431DBCCD2800E3304E /* Sync.h */; settings = {ATTRIBUTES = (Public, ); }; };

--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -282,6 +282,9 @@
 		14975CDD1DBC374C0024901A /* users.json in Resources */ = {isa = PBXBuildFile; fileRef = 445D3BC21D9F9373007F9E26 /* users.json */; };
 		14975CDE1DBC374C0024901A /* users2.json in Resources */ = {isa = PBXBuildFile; fileRef = 445D3BC31D9F9373007F9E26 /* users2.json */; };
 		14975CDF1DBC374C0024901A /* users3.json in Resources */ = {isa = PBXBuildFile; fileRef = 445D3BC41D9F9373007F9E26 /* users3.json */; };
+		14BA60E91DC0247700C97D6F /* SyncDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14BA60E81DC0247700C97D6F /* SyncDelegateTests.swift */; };
+		14BA60EA1DC0247700C97D6F /* SyncDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14BA60E81DC0247700C97D6F /* SyncDelegateTests.swift */; };
+		14BA60EB1DC0247700C97D6F /* SyncDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14BA60E81DC0247700C97D6F /* SyncDelegateTests.swift */; };
 		14C046351DBC19D300CB6C16 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C046341DBC19D300CB6C16 /* JSON.swift */; };
 		14DAB3FD1DBC4620004B455F /* DATAStack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14241F0D1DBC3D7D0042ED81 /* DATAStack.framework */; };
 		14DAB3FE1DBC4620004B455F /* SYNCPropertyMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14241F0E1DBC3D7D0042ED81 /* SYNCPropertyMapper.framework */; };
@@ -513,6 +516,7 @@
 		146D72B11AB782920058798C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		14975BE81DBC368B0024901A /* tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = tvOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		14975BF41DBC36960024901A /* macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = macOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		14BA60E81DC0247700C97D6F /* SyncDelegateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncDelegateTests.swift; sourceTree = "<group>"; };
 		14C046341DBC19D300CB6C16 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		14C0AF801BD6D4230009ECBE /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .travis.yml; sourceTree = "<group>"; };
 		14C0AF811BD6D4230009ECBE /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
@@ -788,6 +792,7 @@
 				4403DC571D9F90B5001C8DA6 /* NSManagedObject+SyncTests.swift */,
 				4403DC581D9F90B5001C8DA6 /* NSManagedObjectContext+SyncTests.swift */,
 				4403DC591D9F90B5001C8DA6 /* SyncTests.swift */,
+				14BA60E81DC0247700C97D6F /* SyncDelegateTests.swift */,
 			);
 			path = Sync;
 			sourceTree = "<group>";
@@ -1522,6 +1527,7 @@
 				4403DC921D9F90B5001C8DA6 /* 151-many-to-many.xcdatamodeld in Sources */,
 				4403DCAD1D9F90B5001C8DA6 /* Recursive.xcdatamodeld in Sources */,
 				4403DCA51D9F90B5001C8DA6 /* id.xcdatamodeld in Sources */,
+				14BA60E91DC0247700C97D6F /* SyncDelegateTests.swift in Sources */,
 				4403DC941D9F90B5001C8DA6 /* 151-ordered-to-many.xcdatamodeld in Sources */,
 				4403DCA71D9F90B5001C8DA6 /* Markets.xcdatamodeld in Sources */,
 				4403DC951D9F90B5001C8DA6 /* 151-to-many.xcdatamodeld in Sources */,
@@ -1578,6 +1584,7 @@
 				14975C001DBC36F00024901A /* Sync.swift in Sources */,
 				14975C011DBC36F00024901A /* DATAFilter.swift in Sources */,
 				14975C031DBC36F00024901A /* TestCheck.swift in Sources */,
+				14BA60EA1DC0247700C97D6F /* SyncDelegateTests.swift in Sources */,
 				14975C041DBC36F00024901A /* JSON.swift in Sources */,
 				14975C051DBC36F00024901A /* Helper.swift in Sources */,
 				14975C061DBC36F00024901A /* 151-many-to-many.xcdatamodeld in Sources */,
@@ -1634,6 +1641,7 @@
 				14975C341DBC37180024901A /* Sync.swift in Sources */,
 				14975C351DBC37180024901A /* DATAFilter.swift in Sources */,
 				14975C371DBC37180024901A /* TestCheck.swift in Sources */,
+				14BA60EB1DC0247700C97D6F /* SyncDelegateTests.swift in Sources */,
 				14975C381DBC37180024901A /* JSON.swift in Sources */,
 				14975C391DBC37180024901A /* Helper.swift in Sources */,
 				14975C3A1DBC37180024901A /* 151-many-to-many.xcdatamodeld in Sources */,

--- a/Source/Sync/Sync.swift
+++ b/Source/Sync/Sync.swift
@@ -2,7 +2,13 @@ import CoreData
 import SYNCPropertyMapper
 import DATAStack
 
+public protocol SyncDelegate: class {
+    func sync(_ sync: Sync, willInsert json: [String: Any]) -> [String: Any]
+}
+
 @objc public class Sync: Operation {
+    public weak var delegate: SyncDelegate?
+
     public struct OperationOptions : OptionSet {
         public let rawValue: Int
 
@@ -33,7 +39,7 @@ import DATAStack
     }
 
     public override var isAsynchronous: Bool {
-        return true
+        return !TestCheck.isTesting
     }
 
     var changes: [[String : Any]]
@@ -50,6 +56,13 @@ import DATAStack
         self.predicate = predicate
         self.parent = parent
         self.context = context
+        self.dataStack = dataStack
+        self.filterOperations = operations
+    }
+
+    public init(changes: [[String : Any]], inEntityNamed entityName: String, dataStack: DATAStack, operations: Sync.OperationOptions = .All) {
+        self.changes = changes
+        self.entityName = entityName
         self.dataStack = dataStack
         self.filterOperations = operations
     }
@@ -243,7 +256,6 @@ import DATAStack
 
         let dataFilterOperations = DATAFilter.Operation(rawValue: operations.rawValue)
         DATAFilter.changes(changes, inEntityNamed: entityName, predicate: finalPredicate, operations: dataFilterOperations, localPrimaryKey: localPrimaryKey, remotePrimaryKey: remotePrimaryKey, context: context, inserted: { JSON in
-
             let created = NSEntityDescription.insertNewObject(forEntityName: entityName, into: context)
             created.sync_fillWithDictionary(JSON, parent: parent, parentRelationship: parentRelationship, dataStack: dataStack, operations: operations)
         }) { JSON, updatedObject in
@@ -295,7 +307,8 @@ import DATAStack
             guard self.isCancelled == false else { return }
 
             let created = NSEntityDescription.insertNewObject(forEntityName: entityName, into: context)
-            created.sync_fillWithDictionary(JSON, parent: parent, parentRelationship: parentRelationship, dataStack: dataStack, operations: operations)
+            let interceptedJSON = self.delegate?.sync(self, willInsert: JSON) ?? JSON
+            created.sync_fillWithDictionary(interceptedJSON, parent: parent, parentRelationship: parentRelationship, dataStack: dataStack, operations: operations)
         }) { JSON, updatedObject in
             guard self.isCancelled == false else { return }
             updatedObject.sync_fillWithDictionary(JSON, parent: parent, parentRelationship: parentRelationship, dataStack: dataStack, operations: operations)

--- a/Source/Sync/Sync.swift
+++ b/Source/Sync/Sync.swift
@@ -3,7 +3,7 @@ import SYNCPropertyMapper
 import DATAStack
 
 public protocol SyncDelegate: class {
-    func sync(_ sync: Sync, willInsert json: [String: Any]) -> [String: Any]
+    func sync(_ sync: Sync, willInsert json: [String: Any], in entityNamed: String) -> [String: Any]
 }
 
 @objc public class Sync: Operation {
@@ -307,7 +307,7 @@ public protocol SyncDelegate: class {
             guard self.isCancelled == false else { return }
 
             let created = NSEntityDescription.insertNewObject(forEntityName: entityName, into: context)
-            let interceptedJSON = self.delegate?.sync(self, willInsert: JSON) ?? JSON
+            let interceptedJSON = self.delegate?.sync(self, willInsert: JSON, in: entityName) ?? JSON
             created.sync_fillWithDictionary(interceptedJSON, parent: parent, parentRelationship: parentRelationship, dataStack: dataStack, operations: operations)
         }) { JSON, updatedObject in
             guard self.isCancelled == false else { return }

--- a/Source/Sync/Sync.swift
+++ b/Source/Sync/Sync.swift
@@ -3,7 +3,15 @@ import SYNCPropertyMapper
 import DATAStack
 
 public protocol SyncDelegate: class {
-    func sync(_ sync: Sync, willInsert json: [String: Any], in entityNamed: String) -> [String: Any]
+    /// Called before the JSON is used to create a new NSManagedObject.
+    ///
+    /// - parameter sync:        The Sync operation.
+    /// - parameter json:        The JSON used for filling the contents of the NSManagedObject.
+    /// - parameter entityNamed: The name of the entity to be created.
+    /// - parameter parent:      The new item's parent. Do not mutate the contents of this element.
+    ///
+    /// - returns: The JSON used to create the new NSManagedObject.
+    func sync(_ sync: Sync, willInsert json: [String: Any], in entityNamed: String, parent: NSManagedObject?) -> [String: Any]
 }
 
 @objc public class Sync: Operation {
@@ -307,7 +315,7 @@ public protocol SyncDelegate: class {
             guard self.isCancelled == false else { return }
 
             let created = NSEntityDescription.insertNewObject(forEntityName: entityName, into: context)
-            let interceptedJSON = self.delegate?.sync(self, willInsert: JSON, in: entityName) ?? JSON
+            let interceptedJSON = self.delegate?.sync(self, willInsert: JSON, in: entityName, parent: parent) ?? JSON
             created.sync_fillWithDictionary(interceptedJSON, parent: parent, parentRelationship: parentRelationship, dataStack: dataStack, operations: operations)
         }) { JSON, updatedObject in
             guard self.isCancelled == false else { return }

--- a/Tests/Sync/SyncDelegateTests.swift
+++ b/Tests/Sync/SyncDelegateTests.swift
@@ -22,7 +22,7 @@ class SyncDelegateTests: XCTestCase {
 }
 
 extension SyncDelegateTests: SyncDelegate {
-    func sync(_ sync: Sync, willInsert json: [String: Any], in entityNamed: String) -> [String: Any] {
+    func sync(_ sync: Sync, willInsert json: [String: Any], in entityNamed: String, parent: NSManagedObject?) -> [String: Any] {
         var newJSON = json
         newJSON["localID"] = "local"
 

--- a/Tests/Sync/SyncDelegateTests.swift
+++ b/Tests/Sync/SyncDelegateTests.swift
@@ -22,7 +22,7 @@ class SyncDelegateTests: XCTestCase {
 }
 
 extension SyncDelegateTests: SyncDelegate {
-    func sync(_ sync: Sync, willInsert json: [String: Any]) -> [String: Any] {
+    func sync(_ sync: Sync, willInsert json: [String: Any], in entityNamed: String) -> [String: Any] {
         var newJSON = json
         newJSON["localID"] = "local"
 

--- a/Tests/Sync/SyncDelegateTests.swift
+++ b/Tests/Sync/SyncDelegateTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+import DATAStack
+import CoreData
+
+class SyncDelegateTests: XCTestCase {
+    func testWillInsertJSON() {
+        let dataStack = Helper.dataStackWithModelName("Tests")
+
+        let json = [["id": 9, "completed": false]]
+        let syncOperation = Sync(changes: json, inEntityNamed: "User", dataStack: dataStack)
+        syncOperation.delegate = self
+        XCTAssertEqual(Helper.countForEntity("User", inContext:dataStack.mainContext), 0)
+        syncOperation.start()
+        XCTAssertEqual(Helper.countForEntity("User", inContext:dataStack.mainContext), 1)
+
+        let task = Helper.fetchEntity("User", inContext: dataStack.mainContext).first!
+        XCTAssertEqual(task.value(forKey: "remoteID") as? Int, 9)
+        XCTAssertEqual(task.value(forKey: "localID") as? String, "local")
+
+        try! dataStack.drop()
+    }
+}
+
+extension SyncDelegateTests: SyncDelegate {
+    func sync(_ sync: Sync, willInsert json: [String: Any]) -> [String: Any] {
+        var newJSON = json
+        newJSON["localID"] = "local"
+
+        return newJSON
+    }
+}


### PR DESCRIPTION
Let's you change the structure of the JSON before returning it.

This could be used for cleaning up dates and so on, here I'm using it to make sure that every insert gets a localID.

```swift
func sync(_ sync: Sync, willInsert json: [String: Any], in entityNamed: String) -> [String: Any] {
    var newJSON = json
    newJSON["localID"] = UUID().uuidString

    return newJSON
}
```