### PR TITLE
Improved test on fix/#233

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -432,6 +432,9 @@
 		4E2F71F41DD60115003F0108 /* 233-order-b.json in Resources */ = {isa = PBXBuildFile; fileRef = 4E2F71F21DD60110003F0108 /* 233-order-b.json */; };
 		4E2F71F51DD60116003F0108 /* 233-order-b.json in Resources */ = {isa = PBXBuildFile; fileRef = 4E2F71F21DD60110003F0108 /* 233-order-b.json */; };
 		4E2F71F61DD60116003F0108 /* 233-order-b.json in Resources */ = {isa = PBXBuildFile; fileRef = 4E2F71F21DD60110003F0108 /* 233-order-b.json */; };
+		4E2F71F91DD611EB003F0108 /* 233-slides.json in Resources */ = {isa = PBXBuildFile; fileRef = 4E2F71F71DD611E4003F0108 /* 233-slides.json */; };
+		4E2F71FA1DD611EB003F0108 /* 233-slides.json in Resources */ = {isa = PBXBuildFile; fileRef = 4E2F71F71DD611E4003F0108 /* 233-slides.json */; };
+		4E2F71FB1DD611EC003F0108 /* 233-slides.json in Resources */ = {isa = PBXBuildFile; fileRef = 4E2F71F71DD611E4003F0108 /* 233-slides.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -689,6 +692,7 @@
 		4E2F71E81DD3DD56003F0108 /* 233.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = 233.xcdatamodel; sourceTree = "<group>"; };
 		4E2F71EA1DD3E1B6003F0108 /* 233-order-a.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "233-order-a.json"; sourceTree = "<group>"; };
 		4E2F71F21DD60110003F0108 /* 233-order-b.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "233-order-b.json"; sourceTree = "<group>"; };
+		4E2F71F71DD611E4003F0108 /* 233-slides.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "233-slides.json"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -898,6 +902,7 @@
 				4403DBE91D9F90B5001C8DA6 /* 225-a-null.json */,
 				4403DBEA1D9F90B5001C8DA6 /* 225-a-replaced.json */,
 				4403DBEB1D9F90B5001C8DA6 /* 225-a.json */,
+				4E2F71F71DD611E4003F0108 /* 233-slides.json */,
 				4E2F71EA1DD3E1B6003F0108 /* 233-order-a.json */,
 				4E2F71F21DD60110003F0108 /* 233-order-b.json */,
 				4403DBF71D9F90B5001C8DA6 /* bug-239.json */,
@@ -1401,6 +1406,7 @@
 				4403DC5E1D9F90B5001C8DA6 /* 151-to-many-notes.json in Resources */,
 				4403DC7E1D9F90B5001C8DA6 /* notes_for_user_a.json in Resources */,
 				4403DC8D1D9F90B5001C8DA6 /* users_a.json in Resources */,
+				4E2F71F91DD611EB003F0108 /* 233-slides.json in Resources */,
 				4403DC5B1D9F90B5001C8DA6 /* 151-many-to-many-notes-update.json in Resources */,
 				4403DC5F1D9F90B5001C8DA6 /* 151-to-many-users-update.json in Resources */,
 				4403DC6E1D9F90B5001C8DA6 /* bug-125.json in Resources */,
@@ -1472,6 +1478,7 @@
 				14975C7F1DBC373A0024901A /* bug-number-84.json in Resources */,
 				14975C801DBC373A0024901A /* camelcase.json in Resources */,
 				14975C811DBC373A0024901A /* comments-no-id.json in Resources */,
+				4E2F71FA1DD611EB003F0108 /* 233-slides.json in Resources */,
 				14975C821DBC373A0024901A /* custom_relationship_key_to_many.json in Resources */,
 				14975C831DBC373A0024901A /* custom_relationship_key_to_one.json in Resources */,
 				14975C841DBC373A0024901A /* id.json in Resources */,
@@ -1543,6 +1550,7 @@
 				14975CBD1DBC374C0024901A /* bug-number-84.json in Resources */,
 				14975CBE1DBC374C0024901A /* camelcase.json in Resources */,
 				14975CBF1DBC374C0024901A /* comments-no-id.json in Resources */,
+				4E2F71FB1DD611EC003F0108 /* 233-slides.json in Resources */,
 				14975CC01DBC374C0024901A /* custom_relationship_key_to_many.json in Resources */,
 				14975CC11DBC374C0024901A /* custom_relationship_key_to_one.json in Resources */,
 				14975CC21DBC374C0024901A /* id.json in Resources */,

--- a/Tests/Sync/JSONs/233-order-a.json
+++ b/Tests/Sync/JSONs/233-order-a.json
@@ -2,6 +2,6 @@
  {
     "id": 1,
     "name": "My Presentation - Order A",
-    "slide_ids": [ 1, 2, 3 ]
-  }
+    "slides_ids": [ 1, 2, 3 ]
+ }
 ]

--- a/Tests/Sync/JSONs/233-order-b.json
+++ b/Tests/Sync/JSONs/233-order-b.json
@@ -1,7 +1,7 @@
 [
  {
     "id": 1,
-    "name": "My Presentation - First Draft",
-    "slide_ids": [ 3, 2, 1 ]
+    "name": "My Presentation - Order B",
+    "slides_ids": [ 3, 2, 1 ]
  }
 ]

--- a/Tests/Sync/JSONs/233-slides.json
+++ b/Tests/Sync/JSONs/233-slides.json
@@ -1,0 +1,14 @@
+[
+ {
+    "id": 1,
+    "text": "Welcome",
+ },
+  {
+    "id": 2,
+    "text": "Who am I?",
+ },
+ {
+    "id": 3,
+    "text": "Agenda",
+ }
+]

--- a/Tests/Sync/Models/233.xcdatamodeld/233.xcdatamodel/contents
+++ b/Tests/Sync/Models/233.xcdatamodeld/233.xcdatamodel/contents
@@ -8,7 +8,7 @@
     <entity name="Slide" representedClassName="Slide" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="YES" attributeType="Integer 16" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="text" attributeType="String" syncable="YES"/>
-        <relationship name="presentation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Presentation" inverseName="slides" inverseEntity="Presentation" syncable="YES"/>
+        <relationship name="presentation" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Presentation" inverseName="slides" inverseEntity="Presentation" syncable="YES"/>
     </entity>
     <elements>
         <element name="Presentation" positionX="-54" positionY="-9" width="128" height="90"/>

--- a/Tests/Sync/SyncTests.swift
+++ b/Tests/Sync/SyncTests.swift
@@ -1209,28 +1209,31 @@ class SyncTests: XCTestCase {
     func test233() {
         let dataStack = Helper.dataStackWithModelName("233")
 
+        let slides = Helper.objectsFromJSON("233-slides.json") as! [[String : Any]]
+        Sync.changes(slides, inEntityNamed: "Slide", dataStack: dataStack, completion: nil)
+
+        XCTAssertEqual(Helper.countForEntity("Slide", inContext:dataStack.mainContext), 3)
+
         // load order a
         let presentationOrderA = Helper.objectsFromJSON("233-order-a.json") as! [[String : Any]]
         Sync.changes(presentationOrderA, inEntityNamed: "Presentation", dataStack: dataStack, completion: nil)
 
         XCTAssertEqual(Helper.countForEntity("Presentation", inContext:dataStack.mainContext), 1)
-        XCTAssertEqual(Helper.countForEntity("Slide", inContext:dataStack.mainContext), 3)
 
-        let lastSlideA = Helper.fetchEntity("Slide", inContext: dataStack.mainContext).last!
-        let lastSlideAId = lastSlideA.value(forKey: "id") as! Int16
+        let lastSlideA = Helper.fetchEntity("Presentation", inContext: dataStack.mainContext).first!.mutableOrderedSetValue(forKey: "slides").lastObject as! NSManagedObject
+        let lastSlideAText = lastSlideA.value(forKey: "text") as! String
 
         // load order b
         let presentationOrderB = Helper.objectsFromJSON("233-order-b.json") as! [[String : Any]]
         Sync.changes(presentationOrderB, inEntityNamed: "Presentation", dataStack: dataStack, completion: nil)
 
         XCTAssertEqual(Helper.countForEntity("Presentation", inContext:dataStack.mainContext), 1)
-        XCTAssertEqual(Helper.countForEntity("Slide", inContext:dataStack.mainContext), 3)
 
-        let firstSlideB = Helper.fetchEntity("Slide", inContext: dataStack.mainContext).first!
-        let firstSlideBId = firstSlideB.value(forKey: "id") as! Int16
+        let firstSlideB = Helper.fetchEntity("Presentation", inContext: dataStack.mainContext).first!.mutableOrderedSetValue(forKey: "slides").firstObject as! NSManagedObject
+        let firstSlideBText = firstSlideB.value(forKey: "text") as! String
 
         // check if order is properly updated
-        XCTAssertEqual(lastSlideAId, firstSlideBId)
+        XCTAssertEqual(lastSlideAText, firstSlideBText)
     }
 
     func test280() {


### PR DESCRIPTION
This PR includes minor updates to the test case for #233.

First way to solve the issue itself might be to update the `guard` in `sync_toManyRelationshipUsingIDsInsteadOfDictionary` to:

    guard insertedItems.count > 0 || deletedItems.count > 0 || (insertedItems.count == 0 && deletedItems.count == 0 && relationship.isOrdered) else { return }

and find a way to update the `localItems` without using `insertedItems` and `deletedItems` since they are both empty. 

A solution for syncing the order when items are added as well might prove easier. But I suppose both ways should be covered.