### PR TITLE
Rename hyper.isPrimaryKey to sync.isPrimaryKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ Sync requires your entities to have a primary key, this is important for diffing
 
 By default **Sync** uses `id` from the JSON and `id` (or `remoteID`) from Core Data as the primary key.
 
-You can mark any attribute as primary key by adding `hyper.isPrimaryKey` and the value `true` (or `YES`). For example, in our [Designer News](https://github.com/SyncDB/DesignerNewsDemo) project we have a `Comment` entity that uses `body` as the primary key.
+You can mark any attribute as primary key by adding `sync.isPrimaryKey` and the value `true` (or `YES`). For example, in our [Designer News](https://github.com/SyncDB/DesignerNewsDemo) project we have a `Comment` entity that uses `body` as the primary key.
 
 ![Custom primary key](https://raw.githubusercontent.com/SyncDB/Sync/master/Images/custom-primary-key-v3.png)
 
-If you add the flag `hyper.isPrimaryKey` to the attribute `contractID` then:
+If you add the flag `sync.isPrimaryKey` to the attribute `contractID` then:
 
 - Local primary key will be: `contractID`
 - Remote primary key will be: `contract_id`
@@ -457,7 +457,7 @@ If you're using Swift to be able to use `NSNotificationCenter` your class should
 
 #### Crash on NSParameterAssert
 
-This means that the local primary key was not found, Sync uses `id` (or `remoteID`) by default, but if you have another local primary key make sure to mark it with `"hyper.isPrimaryKey" : "true"` in your attribute's user info. For more information check the [Primary Key](https://github.com/SyncDB/Sync#primary-key) section.
+This means that the local primary key was not found, Sync uses `id` (or `remoteID`) by default, but if you have another local primary key make sure to mark it with `"sync.isPrimaryKey" : "true"` in your attribute's user info. For more information check the [Primary Key](https://github.com/SyncDB/Sync#primary-key) section.
 
 ```swift
 let localKey = entity.sync_localPrimaryKey()

--- a/Source/NSEntityDescription-SyncPrimaryKey/NSEntityDescription+SyncPrimaryKey.h
+++ b/Source/NSEntityDescription-SyncPrimaryKey/NSEntityDescription+SyncPrimaryKey.h
@@ -7,14 +7,6 @@ static NSString * const SyncDefaultLocalCompatiblePrimaryKey = @"remoteID";
 
 static NSString * const SyncDefaultRemotePrimaryKey = @"id";
 
-static NSString * const SyncCustomLocalPrimaryKey = @"sync.isPrimaryKey";
-static NSString * const SyncCompatibilityCustomLocalPrimaryKey = @"hyper.isPrimaryKey";
-static NSString * const SyncCustomLocalPrimaryKeyValue = @"YES";
-static NSString * const SyncCustomLocalPrimaryKeyAlternativeValue = @"true";
-
-static NSString * const SyncCustomRemoteKey = @"sync.remoteKey";
-static NSString * const SyncCompatibilityCustomRemoteKey = @"hyper.remoteKey";
-
 @interface NSEntityDescription (SyncPrimaryKey)
 
 /**

--- a/Source/NSEntityDescription-SyncPrimaryKey/NSEntityDescription+SyncPrimaryKey.h
+++ b/Source/NSEntityDescription-SyncPrimaryKey/NSEntityDescription+SyncPrimaryKey.h
@@ -8,6 +8,7 @@ static NSString * const SyncDefaultLocalCompatiblePrimaryKey = @"remoteID";
 static NSString * const SyncDefaultRemotePrimaryKey = @"id";
 
 static NSString * const SyncCustomLocalPrimaryKey = @"sync.isPrimaryKey";
+static NSString * const SyncCompatibilityCustomLocalPrimaryKey = @"hyper.isPrimaryKey";
 static NSString * const SyncCustomLocalPrimaryKeyValue = @"YES";
 static NSString * const SyncCustomLocalPrimaryKeyAlternativeValue = @"true";
 

--- a/Source/NSEntityDescription-SyncPrimaryKey/NSEntityDescription+SyncPrimaryKey.h
+++ b/Source/NSEntityDescription-SyncPrimaryKey/NSEntityDescription+SyncPrimaryKey.h
@@ -7,7 +7,7 @@ static NSString * const SyncDefaultLocalCompatiblePrimaryKey = @"remoteID";
 
 static NSString * const SyncDefaultRemotePrimaryKey = @"id";
 
-static NSString * const SyncCustomLocalPrimaryKey = @"hyper.isPrimaryKey";
+static NSString * const SyncCustomLocalPrimaryKey = @"sync.isPrimaryKey";
 static NSString * const SyncCustomLocalPrimaryKeyValue = @"YES";
 static NSString * const SyncCustomLocalPrimaryKeyAlternativeValue = @"true";
 
@@ -18,7 +18,7 @@ static NSString * const SyncCompatibilityCustomRemoteKey = @"hyper.remoteKey";
 
 /**
  Returns the Core Data attribute used as the primary key. By default it will look for the attribute named `id`.
- You can mark any attribute as primary key by adding `hyper.isPrimaryKey` and the value `YES` to the Core Data model userInfo.
+ You can mark any attribute as primary key by adding `sync.isPrimaryKey` and the value `YES` to the Core Data model userInfo.
 
  @return The attribute description that represents the primary key.
  */

--- a/Source/NSEntityDescription-SyncPrimaryKey/NSEntityDescription+SyncPrimaryKey.m
+++ b/Source/NSEntityDescription-SyncPrimaryKey/NSEntityDescription+SyncPrimaryKey.m
@@ -11,6 +11,7 @@
     [self.propertiesByName enumerateKeysAndObjectsUsingBlock:^(NSString *key,
                                                                NSAttributeDescription *attributeDescription,
                                                                BOOL *stop) {
+        // TODO: Update here
         NSString *isPrimaryKey = attributeDescription.userInfo[SyncCustomLocalPrimaryKey];
         BOOL hasCustomPrimaryKey = (isPrimaryKey &&
                                     ([isPrimaryKey isEqualToString:SyncCustomLocalPrimaryKeyValue] || [isPrimaryKey isEqualToString:SyncCustomLocalPrimaryKeyAlternativeValue]) );

--- a/Source/NSEntityDescription-SyncPrimaryKey/NSEntityDescription+SyncPrimaryKey.m
+++ b/Source/NSEntityDescription-SyncPrimaryKey/NSEntityDescription+SyncPrimaryKey.m
@@ -11,11 +11,7 @@
     [self.propertiesByName enumerateKeysAndObjectsUsingBlock:^(NSString *key,
                                                                NSAttributeDescription *attributeDescription,
                                                                BOOL *stop) {
-        // TODO: Update here
-        NSString *isPrimaryKey = attributeDescription.userInfo[SyncCustomLocalPrimaryKey];
-        BOOL hasCustomPrimaryKey = (isPrimaryKey &&
-                                    ([isPrimaryKey isEqualToString:SyncCustomLocalPrimaryKeyValue] || [isPrimaryKey isEqualToString:SyncCustomLocalPrimaryKeyAlternativeValue]) );
-        if (hasCustomPrimaryKey) {
+        if (attributeDescription.isCustomPrimaryKey) {
             primaryKeyAttribute = attributeDescription;
             *stop = YES;
         }

--- a/Source/NSPropertyDescription-Sync/NSPropertyDescription+Sync.h
+++ b/Source/NSPropertyDescription-Sync/NSPropertyDescription+Sync.h
@@ -2,6 +2,8 @@
 
 @interface NSPropertyDescription (Sync)
 
+@property (readonly) BOOL isCustomPrimaryKey;
+
 @property (nonatomic, nullable, readonly) NSString *customKey;
 
 @end

--- a/Source/NSPropertyDescription-Sync/NSPropertyDescription+Sync.m
+++ b/Source/NSPropertyDescription-Sync/NSPropertyDescription+Sync.m
@@ -2,6 +2,14 @@
 
 #import "NSEntityDescription+SyncPrimaryKey.h"
 
+static NSString * const SyncCustomLocalPrimaryKey = @"sync.isPrimaryKey";
+static NSString * const SyncCompatibilityCustomLocalPrimaryKey = @"hyper.isPrimaryKey";
+static NSString * const SyncCustomLocalPrimaryKeyValue = @"YES";
+static NSString * const SyncCustomLocalPrimaryKeyAlternativeValue = @"true";
+
+static NSString * const SyncCustomRemoteKey = @"sync.remoteKey";
+static NSString * const SyncCompatibilityCustomRemoteKey = @"hyper.remoteKey";
+
 @implementation NSPropertyDescription (Sync)
 
 - (BOOL)isCustomPrimaryKey {

--- a/Source/NSPropertyDescription-Sync/NSPropertyDescription+Sync.m
+++ b/Source/NSPropertyDescription-Sync/NSPropertyDescription+Sync.m
@@ -4,6 +4,18 @@
 
 @implementation NSPropertyDescription (Sync)
 
+- (BOOL)isCustomPrimaryKey {
+    NSString *keyName = self.userInfo[SyncCustomLocalPrimaryKey];
+    if (keyName == nil) {
+        keyName = self.userInfo[SyncCompatibilityCustomLocalPrimaryKey];
+    }
+
+    BOOL hasCustomPrimaryKey = (keyName &&
+                                ([keyName isEqualToString:SyncCustomLocalPrimaryKeyValue] || [keyName isEqualToString:SyncCustomLocalPrimaryKeyAlternativeValue]) );
+
+    return hasCustomPrimaryKey;
+}
+
 - (NSString *)customKey {
     NSString *keyName = self.userInfo[SyncCustomRemoteKey];
     if (keyName == nil) {

--- a/Source/Sync/Sync.swift
+++ b/Source/Sync/Sync.swift
@@ -137,7 +137,7 @@ public protocol SyncDelegate: class {
         }
 
         if localPrimaryKey.isEmpty {
-            fatalError("Local primary key not found for entity: \(entityName), add a primary key named id or mark an existing attribute using hyper.isPrimaryKey")
+            fatalError("Local primary key not found for entity: \(entityName), add a primary key named id or mark an existing attribute using sync.isPrimaryKey")
         }
 
         if remotePrimaryKey.isEmpty {

--- a/Tests/NSEntityDescription-SyncPrimaryKey/PrimaryKeyTests.m
+++ b/Tests/NSEntityDescription-SyncPrimaryKey/PrimaryKeyTests.m
@@ -76,7 +76,7 @@
     XCTAssertEqualObjects([entity sync_localPrimaryKey], @"alternativeID");
 
     entity = [self entityForName:@"Compatibility"];
-    XCTAssertEqualObjects([entity sync_localPrimaryKey], @"id");
+    XCTAssertEqualObjects([entity sync_localPrimaryKey], @"custom");
 }
 
 - (void)testRemotePrimaryKey {

--- a/Tests/NSEntityDescription-SyncPrimaryKey/SyncPrimaryKey.xcdatamodeld/SyncPrimaryKey.xcdatamodel/contents
+++ b/Tests/NSEntityDescription-SyncPrimaryKey/SyncPrimaryKey.xcdatamodeld/SyncPrimaryKey.xcdatamodel/contents
@@ -3,7 +3,7 @@
     <entity name="AlternativeID" syncable="YES">
         <attribute name="alternativeID" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="true"/>
+                <entry key="sync.isPrimaryKey" value="true"/>
             </userInfo>
         </attribute>
     </entity>
@@ -21,7 +21,7 @@
         <attribute name="attribute" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="uniqueID" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
     </entity>
@@ -33,7 +33,7 @@
         <attribute name="attribute" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="randomId" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
                 <entry key="sync.remoteKey" value="id"/>
             </userInfo>
         </attribute>

--- a/Tests/NSEntityDescription-SyncPrimaryKey/SyncPrimaryKey.xcdatamodeld/SyncPrimaryKey.xcdatamodel/contents
+++ b/Tests/NSEntityDescription-SyncPrimaryKey/SyncPrimaryKey.xcdatamodeld/SyncPrimaryKey.xcdatamodel/contents
@@ -8,8 +8,9 @@
         </attribute>
     </entity>
     <entity name="Compatibility" syncable="YES">
-        <attribute name="id" optional="YES" attributeType="String" syncable="YES">
+        <attribute name="custom" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
+                <entry key="hyper.isPrimaryKey" value="true"/>
                 <entry key="hyper.remoteKey" value="greeting"/>
             </userInfo>
         </attribute>
@@ -44,11 +45,11 @@
     </entity>
     <elements>
         <element name="AlternativeID" positionX="-27" positionY="18" width="128" height="60"/>
+        <element name="Compatibility" positionX="-27" positionY="18" width="128" height="60"/>
         <element name="NoID" positionX="-27" positionY="18" width="128" height="60"/>
         <element name="Note" positionX="-20" positionY="18" width="128" height="75"/>
         <element name="SimpleID" positionX="-27" positionY="18" width="128" height="75"/>
         <element name="Tag" positionX="160" positionY="0" width="128" height="75"/>
         <element name="User" positionX="-207" positionY="-15" width="128" height="73"/>
-        <element name="Compatibility" positionX="-27" positionY="18" width="128" height="60"/>
     </elements>
 </model>

--- a/Tests/Sync/Models/113.xcdatamodeld/113.xcdatamodel/contents
+++ b/Tests/Sync/Models/113.xcdatamodeld/113.xcdatamodel/contents
@@ -3,7 +3,7 @@
     <entity name="AwesomeComment" syncable="YES">
         <attribute name="body" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
         <relationship name="awesomeComments" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AwesomeComment" inverseName="awesomeComments" inverseEntity="AwesomeComment" syncable="YES"/>

--- a/Tests/Sync/Models/125.xcdatamodeld/125.xcdatamodel/contents
+++ b/Tests/Sync/Models/125.xcdatamodeld/125.xcdatamodel/contents
@@ -3,7 +3,7 @@
     <entity name="Element" syncable="YES">
         <attribute name="label" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
         <relationship name="element" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Element" inverseName="elements" inverseEntity="Element" syncable="YES"/>
@@ -14,7 +14,7 @@
     <entity name="Form" syncable="YES">
         <attribute name="uri" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
         <relationship name="element" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Element" inverseName="form" inverseEntity="Element" syncable="YES"/>
@@ -23,7 +23,7 @@
     <entity name="Model" syncable="YES">
         <attribute name="uri" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
         <relationship name="form" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Form" inverseName="model" inverseEntity="Form" syncable="YES"/>
@@ -37,7 +37,7 @@
     <entity name="Restriction" syncable="YES">
         <attribute name="restriction" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
         <relationship name="property" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ModelProperty" inverseName="restrictions" inverseEntity="ModelProperty" syncable="YES"/>
@@ -45,7 +45,7 @@
     <entity name="SelectionItem" syncable="YES">
         <attribute name="value" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
         <relationship name="element" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Element" inverseName="items" inverseEntity="Element" syncable="YES"/>

--- a/Tests/Sync/Models/151-many-to-many.xcdatamodeld/151-many-to-many.xcdatamodel/contents
+++ b/Tests/Sync/Models/151-many-to-many.xcdatamodeld/151-many-to-many.xcdatamodel/contents
@@ -4,7 +4,7 @@
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="noteID" attributeType="Integer 32" defaultValueString="0" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="true"/>
+                <entry key="sync.isPrimaryKey" value="true"/>
                 <entry key="sync.remoteKey" value="id"/>
             </userInfo>
         </attribute>
@@ -14,7 +14,7 @@
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="tagID" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="true"/>
+                <entry key="sync.isPrimaryKey" value="true"/>
                 <entry key="sync.remoteKey" value="id"/>
             </userInfo>
         </attribute>

--- a/Tests/Sync/Models/151-to-many.xcdatamodeld/151-to-many.xcdatamodel/contents
+++ b/Tests/Sync/Models/151-to-many.xcdatamodeld/151-to-many.xcdatamodel/contents
@@ -4,7 +4,7 @@
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="noteID" attributeType="Integer 32" defaultValueString="0" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
                 <entry key="sync.remoteKey" value="id"/>
             </userInfo>
         </attribute>
@@ -14,7 +14,7 @@
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="userID" attributeType="Integer 32" defaultValueString="0" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
                 <entry key="sync.remoteKey" value="id"/>
             </userInfo>
         </attribute>

--- a/Tests/Sync/Models/157.xcdatamodeld/157.xcdatamodel/contents
+++ b/Tests/Sync/Models/157.xcdatamodeld/157.xcdatamodel/contents
@@ -3,7 +3,7 @@
     <entity name="City" syncable="YES">
         <attribute name="cityID" attributeType="Integer 16" defaultValueString="0" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
                 <entry key="sync.remoteKey" value="id"/>
             </userInfo>
         </attribute>
@@ -13,7 +13,7 @@
     <entity name="Location" syncable="YES">
         <attribute name="locationID" attributeType="Integer 16" defaultValueString="0" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
                 <entry key="sync.remoteKey" value="id"/>
             </userInfo>
         </attribute>

--- a/Tests/Sync/Models/179.xcdatamodeld/179.xcdatamodel/contents
+++ b/Tests/Sync/Models/179.xcdatamodeld/179.xcdatamodel/contents
@@ -3,7 +3,7 @@
     <entity name="Place" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
         <relationship name="endRoutes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Route" inverseName="endPlace" inverseEntity="Route" syncable="YES"/>
@@ -12,7 +12,7 @@
     <entity name="Route" syncable="YES">
         <attribute name="ident" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
         <relationship name="endPlace" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Place" inverseName="endRoutes" inverseEntity="Place" syncable="YES">

--- a/Tests/Sync/Models/239.xcdatamodeld/239.xcdatamodel/contents
+++ b/Tests/Sync/Models/239.xcdatamodeld/239.xcdatamodel/contents
@@ -7,7 +7,7 @@
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="remoteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
         <relationship name="car" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Car" inverseName="passengers" inverseEntity="Car" syncable="YES"/>
@@ -16,7 +16,7 @@
         <attribute name="maxSpeed" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="remoteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
     </entity>

--- a/Tests/Sync/Models/277.xcdatamodeld/239.xcdatamodel/contents
+++ b/Tests/Sync/Models/277.xcdatamodeld/239.xcdatamodel/contents
@@ -6,7 +6,7 @@
     <entity name="Passenger" syncable="YES">
         <attribute name="remoteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
         <relationship name="cars" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Car" inverseName="passengers" inverseEntity="Car" syncable="YES"/>
@@ -14,7 +14,7 @@
     <entity name="Racecar" parentEntity="Car" syncable="YES">
         <attribute name="remoteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
     </entity>

--- a/Tests/Sync/Models/280.xcdatamodeld/151-many-to-many.xcdatamodel/contents
+++ b/Tests/Sync/Models/280.xcdatamodeld/151-many-to-many.xcdatamodel/contents
@@ -3,7 +3,7 @@
     <entity name="Route" syncable="YES">
         <attribute name="busID" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="true"/>
+                <entry key="sync.isPrimaryKey" value="true"/>
                 <entry key="sync.remoteKey" value="busID"/>
             </userInfo>
         </attribute>
@@ -13,7 +13,7 @@
     <entity name="RoutePolylineItem" syncable="YES">
         <attribute name="index" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="true"/>
+                <entry key="sync.isPrimaryKey" value="true"/>
             </userInfo>
         </attribute>
         <relationship name="route" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Route" inverseName="polyline" inverseEntity="Route" syncable="YES"/>
@@ -21,7 +21,7 @@
     <entity name="RouteStop" syncable="YES">
         <attribute name="index" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="true"/>
+                <entry key="sync.isPrimaryKey" value="true"/>
             </userInfo>
         </attribute>
         <relationship name="route" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Route" inverseName="stops" inverseEntity="Route" syncable="YES"/>

--- a/Tests/Sync/Models/84.xcdatamodeld/84.xcdatamodel/contents
+++ b/Tests/Sync/Models/84.xcdatamodeld/84.xcdatamodel/contents
@@ -4,7 +4,7 @@
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="xid" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
         <relationship name="staff" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MSStaff" inverseName="fulfillers" inverseEntity="MSStaff" syncable="YES"/>
@@ -13,7 +13,7 @@
         <attribute name="image" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="xid" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
         <relationship name="fulfillers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MSFulfiller" inverseName="staff" inverseEntity="MSFulfiller" syncable="YES"/>

--- a/Tests/Sync/Models/Contacts.xcdatamodeld/Demo.xcdatamodel/contents
+++ b/Tests/Sync/Models/Contacts.xcdatamodeld/Demo.xcdatamodel/contents
@@ -8,7 +8,7 @@
     <entity name="Image" syncable="YES">
         <attribute name="imageId" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
                 <entry key="sync.remoteKey" value="ImageId"/>
             </userInfo>
         </attribute>

--- a/Tests/Sync/Models/Markets.xcdatamodeld/Demo.xcdatamodel/contents
+++ b/Tests/Sync/Models/Markets.xcdatamodeld/Demo.xcdatamodel/contents
@@ -4,7 +4,7 @@
         <attribute name="otherAttribute" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="uniqueId" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
                 <entry key="sync.remoteKey" value="id"/>
             </userInfo>
         </attribute>
@@ -14,7 +14,7 @@
         <attribute name="otherAttribute" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="uniqueId" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
                 <entry key="sync.remoteKey" value="id"/>
             </userInfo>
         </attribute>

--- a/Tests/Sync/Models/OrderedSocial.xcdatamodeld/Demo.xcdatamodel/contents
+++ b/Tests/Sync/Models/OrderedSocial.xcdatamodeld/Demo.xcdatamodel/contents
@@ -3,7 +3,7 @@
     <entity name="Comment" syncable="YES">
         <attribute name="body" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
         <relationship name="comments" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Comment" inverseName="comments" inverseEntity="Comment" syncable="YES"/>

--- a/Tests/Sync/Models/Social.xcdatamodeld/Demo.xcdatamodel/contents
+++ b/Tests/Sync/Models/Social.xcdatamodeld/Demo.xcdatamodel/contents
@@ -3,7 +3,7 @@
     <entity name="SocialComment" syncable="YES">
         <attribute name="body" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
         <relationship name="comments" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SocialComment" inverseName="comments" inverseEntity="SocialComment" syncable="YES"/>

--- a/Tests/SyncPropertyMapper/Models/140.xcdatamodeld/smartworkout.xcdatamodel/contents
+++ b/Tests/SyncPropertyMapper/Models/140.xcdatamodeld/smartworkout.xcdatamodel/contents
@@ -20,7 +20,7 @@
         <attribute name="exerciseName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="id" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="true"/>
+                <entry key="sync.isPrimaryKey" value="true"/>
                 <entry key="sync.remoteKey" value="_id"/>
             </userInfo>
         </attribute>
@@ -31,7 +31,7 @@
     <entity name="ExerciseSet" representedClassName="" syncable="YES">
         <attribute name="id" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="true"/>
+                <entry key="sync.isPrimaryKey" value="true"/>
                 <entry key="sync.remoteKey" value="_id"/>
             </userInfo>
         </attribute>
@@ -44,7 +44,7 @@
     <entity name="Workout" representedClassName="" syncable="YES">
         <attribute name="id" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="true"/>
+                <entry key="sync.isPrimaryKey" value="true"/>
                 <entry key="sync.remoteKey" value="_id"/>
             </userInfo>
         </attribute>

--- a/Tests/SyncPropertyMapper/Models/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Tests/SyncPropertyMapper/Models/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -75,7 +75,7 @@
         <attribute name="otherAttribute" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="uniqueId" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.isPrimaryKey" value="YES"/>
+                <entry key="sync.isPrimaryKey" value="YES"/>
                 <entry key="sync.remoteKey" value="id"/>
             </userInfo>
         </attribute>


### PR DESCRIPTION
Rename `hyper.isPrimaryKey` to `sync.isPrimaryKey` while maintaining compatibility so no changes are needed in existing implementations.