### PR TITLE
Rename hyper.nonExportable to sync.nonExportable

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ Sync uses an extensive and [blazing fast ISO 8601 parser](https://github.com/Syn
 
 #### Infinite loop in hyp_dictionary() with relationships
 
-If you're using hyp_dictionary() and you get a stack overflow because of recursive calls, then is probably because somewhere in your relationships, your model is referencing a model that it's referencing the previous model and so on, then `SyncPropertyMapper` doesn't know when to stop. For this reason we've introduced `hyper.nonExportable`, this flag can be used for both fields and relationships. To fix your issue you need to add the flag to the relationship that shouldn't be exported.
+If you're using hyp_dictionary() and you get a stack overflow because of recursive calls, then is probably because somewhere in your relationships, your model is referencing a model that it's referencing the previous model and so on, then `SyncPropertyMapper` doesn't know when to stop. For this reason we've introduced `sync.nonExportable`, this flag can be used for both fields and relationships. To fix your issue you need to add the flag to the relationship that shouldn't be exported.
 
 [More information here.](https://github.com/SyncDB/Sync/tree/master/Source/NSManagedObject-SyncPropertyMapper#excluding)
 

--- a/Source/NSManagedObject-SyncPropertyMapper/NSManagedObject+SyncPropertyMapperHelpers.h
+++ b/Source/NSManagedObject-SyncPropertyMapper/NSManagedObject+SyncPropertyMapperHelpers.h
@@ -4,7 +4,7 @@
 
 static NSString * const SyncPropertyMapperDestroyKey = @"destroy";
 static NSString * const SyncPropertyMapperCustomValueTransformerKey = @"hyper.valueTransformer";
-static NSString * const SyncPropertyMapperNonExportableKey = @"hyper.nonExportable";
+static NSString * const SyncPropertyMapperNonExportableKey = @"sync.nonExportable";
 
 /**
  Internal helpers, not meant to be included in the public APIs.

--- a/Source/NSManagedObject-SyncPropertyMapper/NSManagedObject+SyncPropertyMapperHelpers.h
+++ b/Source/NSManagedObject-SyncPropertyMapper/NSManagedObject+SyncPropertyMapperHelpers.h
@@ -4,7 +4,6 @@
 
 static NSString * const SyncPropertyMapperDestroyKey = @"destroy";
 static NSString * const SyncPropertyMapperCustomValueTransformerKey = @"hyper.valueTransformer";
-static NSString * const SyncPropertyMapperNonExportableKey = @"sync.nonExportable";
 
 /**
  Internal helpers, not meant to be included in the public APIs.

--- a/Source/NSManagedObject-SyncPropertyMapper/README.md
+++ b/Source/NSManagedObject-SyncPropertyMapper/README.md
@@ -250,7 +250,7 @@ That's it, that's all you have to do, the keys will be magically transformed int
 
 ## Excluding
 
-If you don't want to export attribute / relationship, you can prohibit exporting by adding `hyper.nonExportable` in the user info of the excluded attribute or relationship.
+If you don't want to export attribute / relationship, you can prohibit exporting by adding `sync.nonExportable` in the user info of the excluded attribute or relationship.
 
 ![non-exportable](https://raw.githubusercontent.com/SyncDB/Sync/master/Images/pm-non-exportable.png)
 

--- a/Source/NSManagedObject-SyncPropertyMapper/SyncPropertyMapper.m
+++ b/Source/NSManagedObject-SyncPropertyMapper/SyncPropertyMapper.m
@@ -3,6 +3,7 @@
 #import "NSString+SyncInflections.h"
 #import "NSManagedObject+SyncPropertyMapperHelpers.h"
 #import "NSDate+SyncPropertyMapper.h"
+#import "NSPropertyDescription+Sync.h"
 
 static NSString * const SyncPropertyMapperNestedAttributesKey = @"attributes";
 
@@ -137,10 +138,7 @@ static NSString * const SyncPropertyMapperNestedAttributesKey = @"attributes";
 
     for (id propertyDescription in self.entity.properties) {
         if ([propertyDescription isKindOfClass:[NSAttributeDescription class]]) {
-            NSDictionary *userInfo = [propertyDescription userInfo];
-            NSString *nonExportableKey = userInfo[SyncPropertyMapperNonExportableKey];
-            BOOL shouldExportAttribute = (nonExportableKey == nil);
-            if (shouldExportAttribute) {
+            if ([propertyDescription shouldExportAttribute]) {
                 id value = [self valueForAttributeDescription:propertyDescription
                                                 dateFormatter:dateFormatter
                                              relationshipType:relationshipType];
@@ -154,9 +152,7 @@ static NSString * const SyncPropertyMapperNestedAttributesKey = @"attributes";
         } else if ([propertyDescription isKindOfClass:[NSRelationshipDescription class]] &&
                    relationshipType != SyncPropertyMapperRelationshipTypeNone) {
             NSRelationshipDescription *relationshipDescription = (NSRelationshipDescription *)propertyDescription;
-            NSDictionary *userInfo = relationshipDescription.userInfo;
-            NSString *nonExportableKey = userInfo[SyncPropertyMapperNonExportableKey];
-            if (nonExportableKey == nil) {
+            if ([relationshipDescription shouldExportAttribute]) {
                 BOOL isValidRelationship = !(parent && [parent.entity isEqual:relationshipDescription.destinationEntity] && !relationshipDescription.isToMany);
                 if (isValidRelationship) {
                     NSString *relationshipName = [relationshipDescription name];

--- a/Source/NSPropertyDescription-Sync/NSPropertyDescription+Sync.h
+++ b/Source/NSPropertyDescription-Sync/NSPropertyDescription+Sync.h
@@ -6,4 +6,6 @@
 
 @property (nonatomic, nullable, readonly) NSString *customKey;
 
+@property (readonly) BOOL shouldExportAttribute;
+
 @end

--- a/Source/NSPropertyDescription-Sync/NSPropertyDescription+Sync.m
+++ b/Source/NSPropertyDescription-Sync/NSPropertyDescription+Sync.m
@@ -1,6 +1,7 @@
 #import "NSPropertyDescription+Sync.h"
 
 #import "NSEntityDescription+SyncPrimaryKey.h"
+#import "NSManagedObject+SyncPropertyMapperHelpers.h"
 
 static NSString * const SyncCustomLocalPrimaryKey = @"sync.isPrimaryKey";
 static NSString * const SyncCompatibilityCustomLocalPrimaryKey = @"hyper.isPrimaryKey";
@@ -9,6 +10,9 @@ static NSString * const SyncCustomLocalPrimaryKeyAlternativeValue = @"true";
 
 static NSString * const SyncCustomRemoteKey = @"sync.remoteKey";
 static NSString * const SyncCompatibilityCustomRemoteKey = @"hyper.remoteKey";
+
+static NSString * const SyncPropertyMapperNonExportableKey = @"sync.nonExportable";
+static NSString * const SyncPropertyMapperCompatibilityNonExportableKey = @"hyper.nonExportable";
 
 @implementation NSPropertyDescription (Sync)
 
@@ -31,6 +35,13 @@ static NSString * const SyncCompatibilityCustomRemoteKey = @"hyper.remoteKey";
     }
 
     return keyName;
+}
+
+- (BOOL)shouldExportAttribute {
+    NSString *nonExportableKey = self.userInfo[SyncPropertyMapperNonExportableKey];
+    BOOL shouldExportAttribute = (nonExportableKey == nil);
+
+    return shouldExportAttribute;
 }
 
 @end

--- a/Source/NSPropertyDescription-Sync/NSPropertyDescription+Sync.m
+++ b/Source/NSPropertyDescription-Sync/NSPropertyDescription+Sync.m
@@ -39,6 +39,10 @@ static NSString * const SyncPropertyMapperCompatibilityNonExportableKey = @"hype
 
 - (BOOL)shouldExportAttribute {
     NSString *nonExportableKey = self.userInfo[SyncPropertyMapperNonExportableKey];
+    if (nonExportableKey == nil) {
+        nonExportableKey = self.userInfo[SyncPropertyMapperCompatibilityNonExportableKey];
+    }
+
     BOOL shouldExportAttribute = (nonExportableKey == nil);
 
     return shouldExportAttribute;

--- a/Tests/Sync/NSPropertyDescription+SyncTests.swift
+++ b/Tests/Sync/NSPropertyDescription+SyncTests.swift
@@ -36,4 +36,12 @@ class NSPropertyDescription_SyncTests: XCTestCase {
 
         dataStack.drop()
     }
+
+    func testIsCustomPrimaryKey() {
+        // TODO
+    }
+
+    func testShouldExportAttribute() {
+        // TODO
+    }
 }

--- a/Tests/SyncPropertyMapper/Models/112.xcdatamodeld/hypbug.xcdatamodel/contents
+++ b/Tests/SyncPropertyMapper/Models/112.xcdatamodeld/hypbug.xcdatamodel/contents
@@ -4,12 +4,12 @@
         <attribute name="id" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <relationship name="task" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Task" inverseName="owner" inverseEntity="Task" syncable="YES">
             <userInfo>
-                <entry key="hyper.nonExportable" value="true"/>
+                <entry key="sync.nonExportable" value="true"/>
             </userInfo>
         </relationship>
         <relationship name="taskList" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TaskList" inverseName="owner" inverseEntity="TaskList" syncable="YES">
             <userInfo>
-                <entry key="hyper.nonExportable" value="true"/>
+                <entry key="sync.nonExportable" value="true"/>
             </userInfo>
         </relationship>
     </entity>

--- a/Tests/SyncPropertyMapper/Models/123.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Tests/SyncPropertyMapper/Models/123.xcdatamodeld/Model.xcdatamodel/contents
@@ -4,7 +4,7 @@
         <attribute name="id" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.nonExportable" value="true"/>
+                <entry key="sync.nonExportable" value="true"/>
             </userInfo>
         </attribute>
     </entity>

--- a/Tests/SyncPropertyMapper/Models/137.xcdatamodeld/hypbug.xcdatamodel/contents
+++ b/Tests/SyncPropertyMapper/Models/137.xcdatamodeld/hypbug.xcdatamodel/contents
@@ -4,7 +4,7 @@
         <attribute name="inflectionID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO" syncable="YES"/>
         <relationship name="camelCaseUser" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="InflectionUser" inverseName="camelCaseCompany" inverseEntity="InflectionUser" syncable="YES">
             <userInfo>
-                <entry key="hyper.nonExportable" value="value"/>
+                <entry key="sync.nonExportable" value="value"/>
             </userInfo>
         </relationship>
     </entity>
@@ -16,7 +16,7 @@
         </attribute>
         <attribute name="ignoredParameter" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="hyper.nonExportable" value="true"/>
+                <entry key="sync.nonExportable" value="true"/>
             </userInfo>
         </attribute>
         <attribute name="ignoreTransformable" optional="YES" attributeType="Transformable" syncable="YES"/>


### PR DESCRIPTION
Renames hyper.nonExportable to sync.nonExportable, while maintaining compatibility for both keys.