### PR TITLE
Rename hyp_dictionary to export

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -612,6 +612,13 @@
 		44B548041DCF27FF009215FA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 44B548021DCF27FF009215FA /* LaunchScreen.storyboard */; };
 		44B5481B1DCF3DED009215FA /* sample.json in Resources */ = {isa = PBXBuildFile; fileRef = 44B5481A1DCF3DED009215FA /* sample.json */; };
 		44B5481E1DCF3E18009215FA /* iOSDemo.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 44B5481C1DCF3E18009215FA /* iOSDemo.xcdatamodeld */; };
+		44F5E55A1E8766C300E17DA0 /* ExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F5E5591E8766C300E17DA0 /* ExportTests.swift */; };
+		44F5E55B1E8766C300E17DA0 /* ExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F5E5591E8766C300E17DA0 /* ExportTests.swift */; };
+		44F5E55C1E8766C300E17DA0 /* ExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F5E5591E8766C300E17DA0 /* ExportTests.swift */; };
+		44F5E55E1E87671E00E17DA0 /* NSManagedObject+Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F5E55D1E87671E00E17DA0 /* NSManagedObject+Export.swift */; };
+		44F5E55F1E87671E00E17DA0 /* NSManagedObject+Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F5E55D1E87671E00E17DA0 /* NSManagedObject+Export.swift */; };
+		44F5E5601E87671E00E17DA0 /* NSManagedObject+Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F5E55D1E87671E00E17DA0 /* NSManagedObject+Export.swift */; };
+		44F5E5611E87671E00E17DA0 /* NSManagedObject+Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F5E55D1E87671E00E17DA0 /* NSManagedObject+Export.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -892,6 +899,8 @@
 		44B548051DCF27FF009215FA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		44B5481A1DCF3DED009215FA /* sample.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = sample.json; sourceTree = "<group>"; };
 		44B5481D1DCF3E18009215FA /* iOSDemo.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = iOSDemo.xcdatamodel; sourceTree = "<group>"; };
+		44F5E5591E8766C300E17DA0 /* ExportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExportTests.swift; sourceTree = "<group>"; };
+		44F5E55D1E87671E00E17DA0 /* NSManagedObject+Export.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Export.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1245,6 +1254,7 @@
 				14867DC71E7AF4D2001D228A /* SyncDictionaryTests.m */,
 				14867DC81E7AF4D2001D228A /* SyncFillWithDictionaryTests.m */,
 				14867DC91E7AF4D2001D228A /* Transformers */,
+				44F5E5591E8766C300E17DA0 /* ExportTests.swift */,
 			);
 			path = SyncPropertyMapper;
 			sourceTree = "<group>";
@@ -1338,6 +1348,7 @@
 				14D93C051E4E65C700DED595 /* NSManagedObject+SyncPropertyMapperHelpers.m */,
 				14D93C061E4E65C700DED595 /* SyncPropertyMapper.h */,
 				14D93C071E4E65C700DED595 /* SyncPropertyMapper.m */,
+				44F5E55D1E87671E00E17DA0 /* NSManagedObject+Export.swift */,
 			);
 			path = "NSManagedObject-SyncPropertyMapper";
 			sourceTree = "<group>";
@@ -2013,6 +2024,7 @@
 				14241EA21DBC3A6F0042ED81 /* NSManagedObject+Sync.swift in Sources */,
 				14241EA31DBC3A6F0042ED81 /* NSManagedObjectContext+Sync.swift in Sources */,
 				14549A0B1E7C2E1000A77F2E /* Sync+Helpers.swift in Sources */,
+				44F5E55E1E87671E00E17DA0 /* NSManagedObject+Export.swift in Sources */,
 				14241EA41DBC3A6F0042ED81 /* Sync.swift in Sources */,
 				142CD2B11DEF3A01002FDABE /* Sync+NSPersistentContainer.swift in Sources */,
 				14AF6AFE1DFC3D88009E5BC4 /* Result.swift in Sources */,
@@ -2039,6 +2051,7 @@
 				14D93C2C1E4E65C700DED595 /* NSManagedObject+SyncPropertyMapperHelpers.m in Sources */,
 				14241EAA1DBC3A770042ED81 /* NSManagedObject+Sync.swift in Sources */,
 				14549A0E1E7C2E1000A77F2E /* Sync+Helpers.swift in Sources */,
+				44F5E5611E87671E00E17DA0 /* NSManagedObject+Export.swift in Sources */,
 				14241EAB1DBC3A770042ED81 /* NSManagedObjectContext+Sync.swift in Sources */,
 				14D93C441E4E65C700DED595 /* NSString+SyncInflections.m in Sources */,
 				14241EAC1DBC3A770042ED81 /* Sync.swift in Sources */,
@@ -2065,6 +2078,7 @@
 				14D93C2D1E4E65C700DED595 /* NSManagedObject+SyncPropertyMapperHelpers.m in Sources */,
 				14241EB21DBC3A7F0042ED81 /* NSManagedObject+Sync.swift in Sources */,
 				14549A0C1E7C2E1000A77F2E /* Sync+Helpers.swift in Sources */,
+				44F5E55F1E87671E00E17DA0 /* NSManagedObject+Export.swift in Sources */,
 				14241EB31DBC3A7F0042ED81 /* NSManagedObjectContext+Sync.swift in Sources */,
 				14D93C451E4E65C700DED595 /* NSString+SyncInflections.m in Sources */,
 				14241EB41DBC3A7F0042ED81 /* Sync.swift in Sources */,
@@ -2091,6 +2105,7 @@
 				14D93C2E1E4E65C700DED595 /* NSManagedObject+SyncPropertyMapperHelpers.m in Sources */,
 				14241EBA1DBC3A880042ED81 /* NSManagedObject+Sync.swift in Sources */,
 				14549A0D1E7C2E1000A77F2E /* Sync+Helpers.swift in Sources */,
+				44F5E5601E87671E00E17DA0 /* NSManagedObject+Export.swift in Sources */,
 				14241EBB1DBC3A880042ED81 /* NSManagedObjectContext+Sync.swift in Sources */,
 				14D93C461E4E65C700DED595 /* NSString+SyncInflections.m in Sources */,
 				14241EBC1DBC3A880042ED81 /* Sync.swift in Sources */,
@@ -2171,6 +2186,7 @@
 				14867F0E1E7AF4D2001D228A /* CustomRelationshipKey.xcdatamodeld in Sources */,
 				14867F471E7AF4D2001D228A /* SyncDelegateTests.swift in Sources */,
 				14867F1A1E7AF4D2001D228A /* Notes.xcdatamodeld in Sources */,
+				44F5E55A1E8766C300E17DA0 /* ExportTests.swift in Sources */,
 				14867EE71E7AF4D2001D228A /* 233.xcdatamodeld in Sources */,
 				14867F0B1E7AF4D2001D228A /* Contacts.xcdatamodeld in Sources */,
 				14867F3B1E7AF4D2001D228A /* NSEntityDescription+SyncTests.swift in Sources */,
@@ -2259,6 +2275,7 @@
 				14867F0F1E7AF4D2001D228A /* CustomRelationshipKey.xcdatamodeld in Sources */,
 				14867F481E7AF4D2001D228A /* SyncDelegateTests.swift in Sources */,
 				14867F1B1E7AF4D2001D228A /* Notes.xcdatamodeld in Sources */,
+				44F5E55B1E8766C300E17DA0 /* ExportTests.swift in Sources */,
 				14867EE81E7AF4D2001D228A /* 233.xcdatamodeld in Sources */,
 				14867F0C1E7AF4D2001D228A /* Contacts.xcdatamodeld in Sources */,
 				14867F3C1E7AF4D2001D228A /* NSEntityDescription+SyncTests.swift in Sources */,
@@ -2347,6 +2364,7 @@
 				14867F101E7AF4D2001D228A /* CustomRelationshipKey.xcdatamodeld in Sources */,
 				14867F491E7AF4D2001D228A /* SyncDelegateTests.swift in Sources */,
 				14867F1C1E7AF4D2001D228A /* Notes.xcdatamodeld in Sources */,
+				44F5E55C1E8766C300E17DA0 /* ExportTests.swift in Sources */,
 				14867EE91E7AF4D2001D228A /* 233.xcdatamodeld in Sources */,
 				14867F0D1E7AF4D2001D228A /* Contacts.xcdatamodeld in Sources */,
 				14867F3D1E7AF4D2001D228A /* NSEntityDescription+SyncTests.swift in Sources */,

--- a/Source/NSManagedObject-SyncPropertyMapper/NSManagedObject+Export.swift
+++ b/Source/NSManagedObject-SyncPropertyMapper/NSManagedObject+Export.swift
@@ -1,0 +1,100 @@
+import CoreData
+
+/// The inflection type used to export the NSManagedObject as JSON.
+///
+/// - snakeCase: Uses snake_case notation.
+/// - camelCase: Uses camelCase notation.
+public enum InflectionType {
+    case snakeCase
+    case camelCase
+}
+
+/// The relationship type used to export the NSManagedObject as JSON.
+///
+/// - array: Normal JSON representation of relationships.
+/// - nested: Uses Ruby on Rails's accepts_nested_attributes_for notation to represent relationships.
+/// - none: Skip all relationships.
+public enum RelationshipType {
+    case array
+    case nested
+    case none
+}
+
+public struct ExportOptions {
+    public var inflectionType: InflectionType
+    public var relationshipType: RelationshipType
+    public var dateFormatter: DateFormatter
+
+    public init() {
+        self.inflectionType = .snakeCase
+        self.relationshipType = .array
+        self.dateFormatter = .default()
+    }
+
+
+    /// Convenience initalizer for a camel cased export.
+    public static var camelCase: ExportOptions {
+        var exportOptions = ExportOptions()
+        exportOptions.inflectionType = .camelCase
+
+        return exportOptions
+    }
+}
+
+public extension NSManagedObject {
+    
+    /// Fills the `NSManagedObject` with the contents of the dictionary using a convention-over-configuration paradigm mapping the Core Data attributes to their conterparts in JSON using snake_case.
+    ///
+    /// - Returns: The JSON dictionary to be used to fill the values of your `NSManagedObject`.
+    public func export() -> [String: Any] {
+        return hyp_dictionary(using: .array)
+    }
+
+    /// Fills the `NSManagedObject` with the contents of the dictionary using a convention-over-configuration paradigm mapping the Core Data attributes to their conterparts in JSON using snake_case.
+    ///
+    /// - Parameter options: The options used to export the JSON, such as inflection type, relationship type and date formatting.
+    /// - Returns: The JSON dictionary to be used to fill the values of your `NSManagedObject`.
+    public func export(using options: ExportOptions) -> [String: Any] {
+        let inflectionType: SyncPropertyMapperInflectionType
+        switch options.inflectionType {
+        case .camelCase:
+            inflectionType = .camelCase
+        case .snakeCase:
+            inflectionType = .snakeCase
+        }
+
+        let relationshipType: SyncPropertyMapperRelationshipType
+        switch options.relationshipType {
+        case .array:
+            relationshipType = .array
+        case .nested:
+            relationshipType = .nested
+        case .none:
+            relationshipType = .none
+        }
+
+        return hyp_dictionary(with: options.dateFormatter, using: inflectionType, andRelationshipType: relationshipType)
+    }
+}
+
+extension DateFormatter {
+    class func `default`() -> DateFormatter {
+        return ExportStorage.shared.formatter
+    }
+}
+
+class ExportStorage {
+    lazy var formatter: DateFormatter = {
+        var formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+
+        return formatter
+    }()
+
+    static let shared: ExportStorage = {
+        let instance = ExportStorage()
+
+        return instance
+    }()
+}

--- a/Source/NSManagedObject-SyncPropertyMapper/SyncPropertyMapper.h
+++ b/Source/NSManagedObject-SyncPropertyMapper/SyncPropertyMapper.h
@@ -24,11 +24,10 @@ typedef NS_ENUM(NSInteger, SyncPropertyMapperRelationshipType) {
 };
 
 /**
- The relationship type used to export the NSManagedObject as JSON.
+ The inflection type used to export the NSManagedObject as JSON.
 
- - SyncPropertyMapperRelationshipTypeNone:   Skip all relationships.
- - SyncPropertyMapperRelationshipTypeArray:  Normal JSON representation of relationships.
- - SyncPropertyMapperRelationshipTypeNested: Uses Ruby on Rails's accepts_nested_attributes_for notation to represent relationships.
+ - SyncPropertyMapperInflectionTypeSnakeCase: Uses snake_case notation.
+ - SyncPropertyMapperInflectionTypeCamelCase: Uses camelCase notation.
  */
 typedef NS_ENUM(NSInteger, SyncPropertyMapperInflectionType) {
     SyncPropertyMapperInflectionTypeSnakeCase = 0,
@@ -46,6 +45,13 @@ typedef NS_ENUM(NSInteger, SyncPropertyMapperInflectionType) {
  @param dictionary The JSON dictionary to be used to fill the values of your @c NSManagedObject.
  */
 - (void)hyp_fillWithDictionary:(NSDictionary<NSString *, id> *)dictionary;
+
+/**
+ Fills the @c NSManagedObject with the contents of the dictionary using a convention-over-configuration paradigm mapping the Core Data attributes to their conterparts in JSON using snake_case.
+
+ @param dictionary The JSON dictionary to be used to fill the values of your @c NSManagedObject.
+ */
+- (void)fillWithDictionary:(NSDictionary<NSString *, id> *)dictionary;
 
 /**
  Creates a @c NSDictionary of values based on the @c NSManagedObject subclass that can be serialized by @c NSJSONSerialization. Includes relationships to other models using Ruby on Rail's nested attributes model.

--- a/Source/NSManagedObject-SyncPropertyMapper/SyncPropertyMapper.m
+++ b/Source/NSManagedObject-SyncPropertyMapper/SyncPropertyMapper.m
@@ -11,6 +11,10 @@ static NSString * const SyncPropertyMapperNestedAttributesKey = @"attributes";
 
 #pragma mark - Public methods
 
+- (void)fillWithDictionary:(NSDictionary<NSString *, id> *)dictionary {
+    [self hyp_fillWithDictionary:dictionary];
+}
+
 - (void)hyp_fillWithDictionary:(NSDictionary<NSString *, id> *)dictionary {
     for (__strong NSString *key in dictionary) {
         id value = [dictionary objectForKey:key];

--- a/Tests/SyncPropertyMapper/ExportTests.swift
+++ b/Tests/SyncPropertyMapper/ExportTests.swift
@@ -1,0 +1,305 @@
+import CoreData
+import XCTest
+import Sync
+
+class ExportTests: XCTestCase {
+    let sampleSnakeCaseJSON = [
+        "description": "reserved",
+        "inflection_binary_data": ["one", "two"],
+        "inflection_date": "1970-01-01",
+        "custom_remote_key": "randomRemoteKey",
+        "inflection_id": 1,
+        "inflection_string": "string",
+        "inflection_integer": 1,
+        "ignored_parameter": "ignored",
+        "ignore_transformable": "string",
+        ] as [String : Any]
+
+    func testExportDictionaryWithSnakeCase() {
+        // Fill in transformable attributes is not supported in Swift 3. Crashes when saving the context.
+        let dataStack = Helper.dataStackWithModelName("137")
+        let user = NSEntityDescription.insertNewObject(forEntityName: "InflectionUser", into: dataStack.mainContext)
+        user.fill(with: self.sampleSnakeCaseJSON)
+        try! dataStack.mainContext.save()
+
+        let compared = [
+            "description": "reserved",
+            "inflection_binary_data": NSKeyedArchiver.archivedData(withRootObject: ["one", "two"]) as NSData,
+            "inflection_date": "1970-01-01",
+            "randomRemoteKey": "randomRemoteKey",
+            "inflection_id": 1,
+            "inflection_string": "string",
+            "inflection_integer": 1
+            ] as [String : Any]
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = TimeZone(identifier: "GMT")
+
+        var exportOptions = ExportOptions()
+        exportOptions.dateFormatter = formatter
+        let result = user.export(using: exportOptions)
+
+        for (key, value) in compared {
+            if let comparedValue = result[key] {
+                XCTAssertEqual(value as? NSObject, comparedValue as? NSObject)
+            }
+        }
+
+        dataStack.drop()
+    }
+
+    func testExportDictionaryWithCamelCase() {
+        // Fill in transformable attributes is not supported in Swift 3. Crashes when saving the context.
+        let dataStack = Helper.dataStackWithModelName("137")
+        let user = NSEntityDescription.insertNewObject(forEntityName: "InflectionUser", into: dataStack.mainContext)
+        user.fill(with: self.sampleSnakeCaseJSON)
+        try! dataStack.mainContext.save()
+
+        let compared = [
+            "description": "reserved",
+            "inflectionBinaryData": NSKeyedArchiver.archivedData(withRootObject: ["one", "two"]) as NSData,
+            "inflectionDate": "1970-01-01",
+            "randomRemoteKey": "randomRemoteKey",
+            "inflectionID": 1,
+            "inflectionString": "string",
+            "inflectionInteger": 1
+            ] as [String : Any]
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = TimeZone(identifier: "GMT")
+
+        var exportOptions = ExportOptions()
+        exportOptions.dateFormatter = formatter
+        exportOptions.inflectionType = .camelCase
+        let result = user.export(using: exportOptions)
+        XCTAssertEqual(compared as NSDictionary, result as NSDictionary)
+
+        dataStack.drop()
+    }
+
+    let sampleSnakeCaseJSONWithRelationship = ["inflection_id": 1] as [String : Any]
+
+    func testExportDictionaryWithSnakeCaseRelationshipArray() {
+        // Fill in transformable attributes is not supported in Swift 3. Crashes when saving the context.
+        let dataStack = Helper.dataStackWithModelName("137")
+        let user = NSEntityDescription.insertNewObject(forEntityName: "InflectionUser", into: dataStack.mainContext)
+        user.fill(with: self.sampleSnakeCaseJSONWithRelationship)
+
+        let company = NSEntityDescription.insertNewObject(forEntityName: "InflectionCompany", into: dataStack.mainContext)
+        company.setValue(NSNumber(value: 1), forKey: "inflectionID")
+        user.setValue(company, forKey: "camelCaseCompany")
+
+        try! dataStack.mainContext.save()
+
+        let compared = [
+            "inflection_binary_data": NSNull(),
+            "inflection_date": NSNull(),
+            "inflection_id": 1,
+            "inflection_integer": NSNull(),
+            "inflection_string": NSNull(),
+            "randomRemoteKey": NSNull(),
+            "description": NSNull(),
+            "camel_case_company": [
+                "inflection_id": 1
+            ]
+            ] as [String : Any]
+
+        let result = user.export()
+        XCTAssertEqual(compared as NSDictionary, result as NSDictionary)
+
+        dataStack.drop()
+    }
+
+    func testExportDictionaryWithCamelCaseRelationshipArray() {
+        // Fill in transformable attributes is not supported in Swift 3. Crashes when saving the context.
+        let dataStack = Helper.dataStackWithModelName("137")
+        let user = NSEntityDescription.insertNewObject(forEntityName: "InflectionUser", into: dataStack.mainContext)
+        user.fill(with: self.sampleSnakeCaseJSONWithRelationship)
+
+        let company = NSEntityDescription.insertNewObject(forEntityName: "InflectionCompany", into: dataStack.mainContext)
+        company.setValue(NSNumber(value: 1), forKey: "inflectionID")
+        user.setValue(company, forKey: "camelCaseCompany")
+
+        try! dataStack.mainContext.save()
+
+        let compared = [
+            "inflectionBinaryData": NSNull(),
+            "inflectionDate": NSNull(),
+            "inflectionID": 1,
+            "inflectionInteger": NSNull(),
+            "inflectionString": NSNull(),
+            "randomRemoteKey": NSNull(),
+            "description": NSNull(),
+            "camelCaseCompany": [
+                "inflectionID": 1
+            ]
+            ] as [String : Any]
+
+
+        let result = user.export(using: .camelCase)
+        XCTAssertEqual(compared as NSDictionary, result as NSDictionary)
+
+        dataStack.drop()
+    }
+
+    func testExportDictionaryWithSnakeCaseRelationshipNested() {
+        // Fill in transformable attributes is not supported in Swift 3. Crashes when saving the context.
+        let dataStack = Helper.dataStackWithModelName("137")
+        let user = NSEntityDescription.insertNewObject(forEntityName: "InflectionUser", into: dataStack.mainContext)
+        user.fill(with: self.sampleSnakeCaseJSONWithRelationship)
+
+        let company = NSEntityDescription.insertNewObject(forEntityName: "InflectionCompany", into: dataStack.mainContext)
+        company.setValue(NSNumber(value: 1), forKey: "inflectionID")
+        user.setValue(company, forKey: "camelCaseCompany")
+
+        try! dataStack.mainContext.save()
+
+        let compared = [
+            "inflection_binary_data": NSNull(),
+            "inflection_date": NSNull(),
+            "inflection_id": 1,
+            "inflection_integer": NSNull(),
+            "inflection_string": NSNull(),
+            "randomRemoteKey": NSNull(),
+            "description": NSNull(),
+            "camel_case_company_attributes": [
+                "inflection_id": 1
+            ]
+            ] as [String : Any]
+
+        var exportOptions = ExportOptions()
+        exportOptions.relationshipType = .nested
+        let result = user.export(using: exportOptions)
+        XCTAssertEqual(compared as NSDictionary, result as NSDictionary)
+
+        dataStack.drop()
+    }
+
+    func testExportDictionaryWithCamelCaseRelationshipNested() {
+        // Fill in transformable attributes is not supported in Swift 3. Crashes when saving the context.
+        let dataStack = Helper.dataStackWithModelName("137")
+        let user = NSEntityDescription.insertNewObject(forEntityName: "InflectionUser", into: dataStack.mainContext)
+        user.fill(with: self.sampleSnakeCaseJSONWithRelationship)
+
+        let company = NSEntityDescription.insertNewObject(forEntityName: "InflectionCompany", into: dataStack.mainContext)
+        company.setValue(NSNumber(value: 1), forKey: "inflectionID")
+        user.setValue(company, forKey: "camelCaseCompany")
+
+        try! dataStack.mainContext.save()
+
+        let compared = [
+            "inflectionBinaryData": NSNull(),
+            "inflectionDate": NSNull(),
+            "inflectionID": 1,
+            "inflectionInteger": NSNull(),
+            "inflectionString": NSNull(),
+            "randomRemoteKey": NSNull(),
+            "description": NSNull(),
+            "camelCaseCompanyAttributes": [
+                "inflectionID": 1
+            ]
+            ] as [String : Any]
+
+        var exportOptions = ExportOptions()
+        exportOptions.inflectionType = .camelCase
+        exportOptions.relationshipType = .nested
+        let result = user.export(using: exportOptions)
+        XCTAssertEqual(compared as NSDictionary, result as NSDictionary)
+
+        dataStack.drop()
+    }
+
+    func testReservedAttributeNotExportingWell() {
+        let dataStack = Helper.dataStackWithModelName("142")
+        let user = NSEntityDescription.insertNewObject(forEntityName: "TwoLetterEntity", into: dataStack.mainContext)
+        user.fill(with: ["description": "test"])
+        try! dataStack.mainContext.save()
+
+        let compared = ["description": "test"] as [String : Any]
+
+        let result = user.export(using: .camelCase)
+        XCTAssertEqual(compared as NSDictionary, result as NSDictionary)
+
+        dataStack.drop()
+    }
+
+    func setUpWorkout(dataStack: DataStack) -> NSManagedObject {
+        let workout = NSEntityDescription.insertNewObject(forEntityName: "Workout", into: dataStack.mainContext)
+        workout.setValue(UUID().uuidString, forKey: "id")
+        workout.setValue(UUID().uuidString, forKey: "workoutDesc")
+        workout.setValue(UUID().uuidString, forKey: "workoutName")
+
+        let calendar = NSEntityDescription.insertNewObject(forEntityName: "Calendar", into: dataStack.mainContext)
+        calendar.setValue(UUID().uuidString, forKey: "eventSourceType")
+        calendar.setValue(UUID().uuidString, forKey: "id")
+        calendar.setValue(NSNumber(value: true), forKey: "isCompleted")
+        calendar.setValue(Date(timeIntervalSince1970: 0), forKey: "start")
+
+        let plannedToIDs = NSMutableSet()
+        plannedToIDs.add(calendar)
+        workout.setValue(plannedToIDs, forKey: "plannedToIDs")
+
+        let exercise = NSEntityDescription.insertNewObject(forEntityName: "Exercise", into: dataStack.mainContext)
+        exercise.setValue(UUID().uuidString, forKey: "exerciseDesc")
+        exercise.setValue(UUID().uuidString, forKey: "exerciseName")
+        exercise.setValue(UUID().uuidString, forKey: "id")
+        exercise.setValue(UUID().uuidString, forKey: "mainMuscle")
+
+        let exerciseSet = NSEntityDescription.insertNewObject(forEntityName: "ExerciseSet", into: dataStack.mainContext)
+        exerciseSet.setValue(UUID().uuidString, forKey: "id")
+        exerciseSet.setValue(NSNumber(value: true), forKey: "isCompleted")
+        exerciseSet.setValue(NSNumber(value: 0), forKey: "setNumber")
+        exerciseSet.setValue(NSNumber(value: 0), forKey: "setReps")
+        exerciseSet.setValue(NSNumber(value: 0), forKey: "setWeight")
+
+        let exerciseSets = NSMutableSet()
+        exerciseSets.add(exerciseSet)
+        exercise.setValue(exerciseSets, forKey: "exerciseSets")
+
+        let workoutExercises = NSMutableSet()
+        workoutExercises.add(exercise)
+        workout.setValue(workoutExercises, forKey: "workoutExercises")
+
+        try! dataStack.mainContext.save()
+
+        return workout
+    }
+
+    func testBug140CamelCase() {
+        let dataStack = Helper.dataStackWithModelName("140")
+
+        let workout = self.setUpWorkout(dataStack: dataStack)
+
+        let result = workout.export(using: .camelCase)
+
+        let rootKeys = Array(result.keys)
+        XCTAssertEqual(rootKeys.count, 5)
+        XCTAssertEqual(rootKeys[0], "plannedToIDs")
+        XCTAssertEqual(rootKeys[1], "workoutName")
+        XCTAssertEqual(rootKeys[2], "_id")
+        XCTAssertEqual(rootKeys[3], "workoutExercises")
+        XCTAssertEqual(rootKeys[4], "workoutDesc")
+
+        dataStack.drop()
+    }
+
+    func testBug140SnakeCase() {
+        let dataStack = Helper.dataStackWithModelName("140")
+
+        let workout = self.setUpWorkout(dataStack: dataStack)
+
+        let result = workout.export()
+
+        let rootKeys = Array(result.keys)
+        XCTAssertEqual(rootKeys.count, 5)
+        XCTAssertEqual(rootKeys[0], "planned_to_ids")
+        XCTAssertEqual(rootKeys[1], "_id")
+        XCTAssertEqual(rootKeys[2], "workout_desc")
+        XCTAssertEqual(rootKeys[3], "workout_name")
+        XCTAssertEqual(rootKeys[4], "workout_exercises")
+        
+        dataStack.drop()
+    }
+}


### PR DESCRIPTION
Again, keeps the old functionality to not break existing apps.

Usage:

```swift
let json = user.export()
```