### PR TITLE
Objective-C support for Sync.changes methods.

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -901,6 +901,7 @@
 		44CFE67D1E87BBE60068185B /* PrimaryKey.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = PrimaryKey.xcdatamodel; sourceTree = "<group>"; };
 		44CFE6851E87BC650068185B /* Inflections.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Inflections.h; sourceTree = "<group>"; };
 		44CFE6861E87BC650068185B /* Inflections.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Inflections.m; sourceTree = "<group>"; };
+		E47FF6201F0002A3004A923A /* Sync+ObjC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Sync+ObjC.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1349,6 +1350,7 @@
 				14549A0A1E7C2E1000A77F2E /* Sync+Helpers.swift */,
 				14D5255E1E7C1EC30063909F /* Sync+NSManagedObjectContext.swift */,
 				142CD2AC1DEF3A01002FDABE /* Sync+NSPersistentContainer.swift */,
+				E47FF6201F0002A3004A923A /* Sync+ObjC.swift */,
 			);
 			path = Sync;
 			sourceTree = "<group>";

--- a/Source/Sync/Sync+ObjC.swift
+++ b/Source/Sync/Sync+ObjC.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+@objc public enum ObjcOperationOptions: Int {
+    case insert = 0
+    case update = 1
+    case delete = 2
+    case insertUpdate = 3
+    case insertDelete = 4
+    case updateDelete = 5
+    case all = 6
+}
+
+public extension Sync {
+    
+    public class func objc_changes(_ changes: [[String: Any]], inEntityNamed entityName: String, dataStack: DataStack, operations: ObjcOperationOptions, completion: ((_ error: NSError?) -> Void)?) {
+        self.changes(changes, inEntityNamed: entityName, dataStack: dataStack, operations: self.operationOptionsFrom(operations), completion: completion)
+    }
+    
+    public class func objc_changes(_ changes: [[String: Any]], inEntityNamed entityName: String, predicate: NSPredicate?, dataStack: DataStack, operations: ObjcOperationOptions, completion: ((_ error: NSError?) -> Void)?) {
+        dataStack.performInNewBackgroundContext { backgroundContext in
+            self.changes(changes, inEntityNamed: entityName, predicate: predicate, dataStack: dataStack, operations: self.operationOptionsFrom(operations), completion: completion)
+        }
+    }
+    
+    private class func operationOptionsFrom(_ objcOperationOptions: ObjcOperationOptions) -> Sync.OperationOptions {
+        switch objcOperationOptions {
+        case .insert:
+            return [.insert]
+        case .update:
+            return [.update]
+        case .delete:
+            return [.delete]
+        case .insertUpdate:
+            return [.insert, .update]
+        case .insertDelete:
+            return [.insert, .delete]
+        case .updateDelete:
+            return [.update, .delete]
+        case .all:
+            return [.all]
+        }
+    }
+    
+}

--- a/Source/Sync/Sync+ObjC.swift
+++ b/Source/Sync/Sync+ObjC.swift
@@ -1,5 +1,7 @@
-import Foundation
-
+/**
+ The enum for Objective-C, equals to Sync.OperationOptions in Swift.
+ Objective-C does not support array of enum as parameter, thus we have listed all possible combinations in this enum.
+ */
 @objc public enum ObjcOperationOptions: Int {
     case insert = 0
     case update = 1
@@ -12,16 +14,45 @@ import Foundation
 
 public extension Sync {
     
+    /**
+     Objective-C Edition
+     Syncs the entity using the received array of dictionaries, maps one-to-many, many-to-many and one-to-one relationships.
+     It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
+     and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
+     entire company object inside the employees dictionary.
+     - parameter changes: The array of dictionaries used in the sync process.
+     - parameter entityName: The name of the entity to be synced.
+     - parameter dataStack: The DataStack instance.
+     - parameter operations: The type of operations to be applied to the data, it should be a value of ObjcOperationOptions.
+     - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
+     */
     public class func objc_changes(_ changes: [[String: Any]], inEntityNamed entityName: String, dataStack: DataStack, operations: ObjcOperationOptions, completion: ((_ error: NSError?) -> Void)?) {
         self.changes(changes, inEntityNamed: entityName, dataStack: dataStack, operations: self.operationOptionsFrom(operations), completion: completion)
     }
     
+    /**
+     Objective-C Edition
+     Syncs the entity using the received array of dictionaries, maps one-to-many, many-to-many and one-to-one relationships.
+     It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
+     and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
+     entire company object inside the employees dictionary.
+     - parameter changes: The array of dictionaries used in the sync process.
+     - parameter entityName: The name of the entity to be synced.
+     - parameter predicate: The predicate used to filter out changes, if you want to exclude some local items to be taken in
+     account in the Sync process, you just need to provide this predicate.
+     - parameter dataStack: The DataStack instance.
+     - parameter operations: The type of operations to be applied to the data, it should be a value of ObjcOperationOptions.
+     - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
+     */
     public class func objc_changes(_ changes: [[String: Any]], inEntityNamed entityName: String, predicate: NSPredicate?, dataStack: DataStack, operations: ObjcOperationOptions, completion: ((_ error: NSError?) -> Void)?) {
         dataStack.performInNewBackgroundContext { backgroundContext in
             self.changes(changes, inEntityNamed: entityName, predicate: predicate, dataStack: dataStack, operations: self.operationOptionsFrom(operations), completion: completion)
         }
     }
     
+    /**
+     Transfer Objective-C enum to Sync.OperationOptions in Swift
+     */
     private class func operationOptionsFrom(_ objcOperationOptions: ObjcOperationOptions) -> Sync.OperationOptions {
         switch objcOperationOptions {
         case .insert:


### PR DESCRIPTION
Hi, @3lvis 
I have added enums to solve the problem in Objective-C. 
I found that Objective-C does not support array of enum as parameter. I mean this
```swift
public class func objc_changes(_ changes: [[String: Any]], inEntityNamed entityName: String, predicate: NSPredicate?, dataStack: DataStack, operations: [ObjcOperationOptions], completion: ((_ error: NSError?) -> Void)?) {

}
```
cannot work.
Thus, I have listed all possible combinations in the new enum.
```swift
@objc public enum ObjcOperationOptions: Int {
    case insert = 0
    case update = 1
    case delete = 2
    case insertUpdate = 3
    case insertDelete = 4
    case updateDelete = 5
    case all = 6
}
```